### PR TITLE
Fix FloatVector getMinMaxResult mis-initialized max index

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/util/FloatVector.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/util/FloatVector.java
@@ -212,7 +212,12 @@ public class FloatVector implements Serializable {
         result.minIndex = i;
       }
     }
-    result.maxIndex = 1;
+    // Initialize maxIndex to the first element of the "max" half of the vector.
+    // The original implementation incorrectly set this to 1 which would
+    // yield wrong indices when the maximum value occurred at index `mid`.
+    // Setting it to `mid` ensures the first candidate from the second half is
+    // considered correctly.
+    result.maxIndex = mid;
     result.maxValue = values[mid];
     for (int i = mid + 1; i < values.length; i++) {
       float curr = values[i];

--- a/core/src/test/java/com/airbnb/aerosolve/core/util/FloatVectorTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/util/FloatVectorTest.java
@@ -80,4 +80,18 @@ public class FloatVectorTest {
     assertEquals(4.0, result.maxValue, 0.1f);
   }
 
+  @Test
+  public void testMinMaxResultWhenMaxAtMid() {
+    // The maximum of the second half occurs at index `mid` (2). The previous
+    // implementation initialized maxIndex to 1 which would have returned an
+    // incorrect index in this case.
+    FloatVector v = new FloatVector(new float[]{1.0f, -2.0f, 5.0f, 4.0f});
+    FloatVector.MinMaxResult result = v.getMinMaxResult();
+    assertEquals(0, result.minIndex);
+    assertEquals(1.0, result.minValue, 0.1f);
+
+    assertEquals(2, result.maxIndex);
+    assertEquals(5.0, result.maxValue, 0.1f);
+  }
+
 }


### PR DESCRIPTION
## Summary
- fix incorrect max index initialization in FloatVector#getMinMaxResult
- add regression test covering case where maximum occurs at mid index

## Testing
- `gradle test` *(fails: Could not resolve org.codehaus.groovy.modules.http-builder:http-builder:0.7.2)*

------
https://chatgpt.com/codex/tasks/task_e_68966e6881ec8331bcd800a6f05bde69